### PR TITLE
fix: update release script to include build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"build:prod": "NODE_ENV=production node build.mjs",
 		"changeset": "changeset",
 		"changeset:version": "changeset version && pnpm install --no-frozen-lockfile && pnpm build",
-		"release": "changeset publish",
+		"release": "pnpm build && changeset publish",
 		"biome:check": "biome check ./",
 		"biome:check-src": "biome check ./src",
 		"biome:check-tests": "biome check ./tests",
@@ -84,6 +84,9 @@
 		"url": "https://github.com/MartinEricsson/watranslator/issues"
 	},
 	"homepage": "https://github.com/MartinEricsson/watranslator#readme",
+	"publishConfig": {
+		"access": "public"
+	},
 	"packageManager": "pnpm@9.10.0",
 	"engines": {
 		"node": ">=22.0.0"


### PR DESCRIPTION
This pull request introduces improvements to the release workflow and package publishing configuration in `package.json`. The main goal is to ensure the package is built before publishing and to set the correct access level for npm publishing.

Release workflow improvements:
* Updated the `release` script to run `pnpm build` before `changeset publish`, ensuring the package is built prior to publishing.

Publishing configuration:
* Added a `publishConfig` section with `"access": "public"` to specify that the package should be published publicly on npm.